### PR TITLE
Unset jaar_blackspotlijst/jaar_ongeval_quickscan

### DIFF
--- a/api/api/serializers.py
+++ b/api/api/serializers.py
@@ -89,22 +89,22 @@ class SpotSerializer(HALSerializer):
                         "jaar_blackspotlijst is required for spot types 'blackspot' and 'wegvak'"
                     ]
                 })
-
-            # type is blackspot or wegvak (redroute), so we need to make sure jaar_ongeval_quickscan is empty
+        else:
+            # type is not blackspot or redroute, so we need to make sure jaar_blackspotlijst is empty
             # note that by setting the attribute to None, it will be emptied in the db.
-            attrs['jaar_ongeval_quickscan'] = None
+            attrs['jaar_blackspotlijst'] = None
 
-        elif spot_type in [Spot.SpotType.protocol_ernstig, Spot.SpotType.protocol_dodelijk]:
+        if spot_type in [Spot.SpotType.protocol_ernstig, Spot.SpotType.protocol_dodelijk]:
             if not attrs.get('jaar_ongeval_quickscan'):
                 raise serializers.ValidationError({
                     'jaar_ongeval_quickscan': [
                         "jaar_ongeval_quickscan is required for spot types 'protocol_ernstig' and 'protocol_dodelijk'"
                     ]
                 })
-
-            # type is protocol_*, so we need to make sure jaar_blackspotlijst is empty
+        else:
+            # type is not protocol_*, so we need to make sure jaar_ongeval_quickscan is empty
             # note that by setting the attribute to None, it will be emptied in the db.
-            attrs['jaar_blackspotlijst'] = None
+            attrs['jaar_ongeval_quickscan'] = None
 
     def validate_point_stadsdeel(self, attrs):
         stadsdeel = attrs.get('stadsdeel')

--- a/api/api/tests/test_serializers.py
+++ b/api/api/tests/test_serializers.py
@@ -124,16 +124,28 @@ class TestSerializers(TestCase):
             self.assertEqual(attrs['jaar_ongeval_quickscan'], None)
 
     def test_validate_spot_types_missing_jaarblackspotlijst(self):
+        # Assert that a ValidationError is raised when 'jaar_blackspotlijst' is missing
+        # when spot_type is either blackspot or wegvak (redroute)
         for spot_type in [Spot.SpotType.blackspot, Spot.SpotType.wegvak]:
             attrs = {'spot_type': spot_type}
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError) as context:
                 self.serializer.validate_spot_types(attrs)
 
+        exception_details = context.exception.detail
+        self.assertEqual(str(exception_details['jaar_blackspotlijst'][0]),
+                         "jaar_blackspotlijst is required for spot types 'blackspot' and 'wegvak'")
+
     def test_validate_spot_types_missing_jaarquickscan(self):
+        # Assert that a ValidationError is raised when 'jaar_ongeval_quickscan' is missing
+        # when spot_type is protocol_*
         for spot_type in [Spot.SpotType.protocol_ernstig, Spot.SpotType.protocol_dodelijk]:
             attrs = {'spot_type': spot_type}
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError) as context:
                 self.serializer.validate_spot_types(attrs)
+
+        exception_details = context.exception.detail
+        self.assertEqual(str(exception_details['jaar_ongeval_quickscan'][0]),
+                         "jaar_ongeval_quickscan is required for spot types 'protocol_ernstig' and 'protocol_dodelijk'")
 
     def test_validate_spot_types_unset_jaarquickscan(self):
         for spot_type in [Spot.SpotType.blackspot, Spot.SpotType.wegvak]:

--- a/api/api/tests/test_serializers.py
+++ b/api/api/tests/test_serializers.py
@@ -122,3 +122,34 @@ class TestSerializers(TestCase):
             self.serializer.validate(attrs)
             self.assertIn('jaar_ongeval_quickscan', attrs)
             self.assertEqual(attrs['jaar_ongeval_quickscan'], None)
+
+    def test_validate_spot_types_missing_jaarblackspotlijst(self):
+        for spot_type in [Spot.SpotType.blackspot, Spot.SpotType.wegvak]:
+            attrs = {'spot_type': spot_type}
+            with self.assertRaises(ValidationError):
+                self.serializer.validate_spot_types(attrs)
+
+    def test_validate_spot_types_missing_jaarquickscan(self):
+        for spot_type in [Spot.SpotType.protocol_ernstig, Spot.SpotType.protocol_dodelijk]:
+            attrs = {'spot_type': spot_type}
+            with self.assertRaises(ValidationError):
+                self.serializer.validate_spot_types(attrs)
+
+    def test_validate_spot_types_unset_jaarquickscan(self):
+        for spot_type in [Spot.SpotType.blackspot, Spot.SpotType.wegvak]:
+            attrs = {'spot_type': spot_type, 'jaar_blackspotlijst': 2019}
+            self.serializer.validate_spot_types(attrs)
+            self.assertEqual(attrs['jaar_ongeval_quickscan'], None)
+
+    def test_validate_spot_types_unset_jaarblackspotlijst(self):
+        for spot_type in [Spot.SpotType.protocol_ernstig, Spot.SpotType.protocol_dodelijk]:
+            attrs = {'spot_type': spot_type, 'jaar_ongeval_quickscan': 2019}
+            self.serializer.validate_spot_types(attrs)
+            self.assertEqual(attrs['jaar_blackspotlijst'], None)
+
+    def test_validate_spot_types_unset_both(self):
+        for spot_type in [Spot.SpotType.risico]:
+            attrs = {'spot_type': spot_type}
+            self.serializer.validate_spot_types(attrs)
+            self.assertEqual(attrs['jaar_blackspotlijst'], None)
+            self.assertEqual(attrs['jaar_ongeval_quickscan'], None)


### PR DESCRIPTION
Jaar blackspotlijst is required when spot_type is blackspot
or redroute, and jaar ongeval quickscan is required when spot_type
is protocol_*.

When the spot type changes, make sure to properly unset the
correct attributes.