### PR TITLE
Removed dynamic Django requirement, made static

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,7 +10,7 @@ datapunt-config-loader==1.1.0
 datapunt-objectstore==2019.4.8
 debtcollector==1.21.0
 defusedxml==0.5.0
-Django>=2.2.9,<2.3
+Django==2.2.9
 django-choices==1.6.2
 django-cors-headers==2.5.2
 django-debug-toolbar==1.11


### PR DESCRIPTION
Ranged requirements like Django>=2.2.9,<2.3 give a false sense of up to date requirements and security. The last deploy might have been months ago, potentially missing critical security releases. Therefore, fixed requirements are much safer, allowing static analysis (such as the Github security alerts) to alert us. 