### PR TITLE
Let uwsgi listen to port 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,12 @@ The blackspots/wbakaart service exposes spots in Amsterdam which have been ident
 
 During an import process a remote XLS file is imported to the Postgres database.
 Through a Django rest framework API these spots are exposed in HAL json and geojson.
-Finally the API acts as an authorization proxy for report documents belonging to a particular spot.
 
 Authentication is done using Keycloak.
 ADW users or Datapunt identity provider users can login with the Keycloak JS library (see [blackspots-frontend](https://github.com/Amsterdam/blackspots-frontend/)).
 
 # Project architecture
 This project follows the setup used in multiple projects and is described here: https://github.com/Amsterdam/opdrachten_team_dev.  
-
-# Deployments
-
-Deployments are triggered automatically after pushing considering the following rules:
-
-## Acceptance deployments
-Jenkins will deploy to acceptance in these situations:
-- Any push to master
-- Any push to a release/* (pre-release branches used for final testing)
-- Any pushed tag with semver formatting (x.y.z)
-
-## Production deployments
-Jenkins will deploy to production in the following situation:
-- Any pushed tag with semver formatting (x.y.z) 
-
-Note that given these rules, any semver tag that is pushed will first be deployed to ACC,
-and immediately after to PROD.
-
 
 # Install
 
@@ -94,7 +75,7 @@ Alternatively everything can be started through Docker using:
 docker-compose up --build
 ```
 
-* The API is available on: `<docker-host>:8001`.
+* The API is available on: `<docker-host>:8000`.
 
 
 # Testing

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -5,7 +5,6 @@ services:
     user: 1000:1000
     ports:
       - 8000:8000
-      - 8001:8001
 
   dev:
     <<: *app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       target: app
     ports:
     - 8000
-    - 8001
     volumes:
       - ./src:/src
       - ./tests:/tests

--- a/src/uwsgi.ini
+++ b/src/uwsgi.ini
@@ -7,7 +7,7 @@ vacuum = true
 processes = 4
 threads = 2
 
-http = :8001
+http = :8000
 wsgi-file = main/wsgi.py
 route = /blackspots/static/(.*) static:/src/static/$1
 


### PR DESCRIPTION
Initially the gatekeeper proxy listened to port 8000 and then
forwarded connections to port 8000.

The proxy has been removed, therefore our app can listen to 8000
directly.