### PR TITLE
Fix/duplicate errors

### DIFF
--- a/src/import_process/process_xls.py
+++ b/src/import_process/process_xls.py
@@ -168,6 +168,7 @@ def create_document(
 
     Document.objects.create(type=doc_type, filename=filename, spot=spot)
 
+
 def upsert_spot(spot_data: dict):
     """
     Upsert a spot if the spot already exists else create the spot with the spot data
@@ -183,6 +184,7 @@ def upsert_spot(spot_data: dict):
         spot = Spot.objects.create(**spot_data)
 
     return spot
+
 
 def process_xls(xls_path, document_list: Optional[DocumentList]):
     book = open_workbook(xls_path)

--- a/src/import_process/process_xls.py
+++ b/src/import_process/process_xls.py
@@ -168,6 +168,21 @@ def create_document(
 
     Document.objects.create(type=doc_type, filename=filename, spot=spot)
 
+def upsert_spot(spot_data: dict):
+    """
+    Upsert a spot if the spot already exists else create the spot with the spot data
+    """
+    try:
+        spot = Spot.objects.get(locatie_id=spot_data['locatie_id'])
+
+        for key, value in spot_data.items():
+            if value is not None and hasattr(spot, key):
+                setattr(spot, key, value)
+
+    except Spot.DoesNotExist as e:
+        spot = Spot.objects.create(**spot_data)
+
+    return spot
 
 def process_xls(xls_path, document_list: Optional[DocumentList]):
     book = open_workbook(xls_path)
@@ -228,7 +243,7 @@ def process_xls(xls_path, document_list: Optional[DocumentList]):
             ),
         }
 
-        [spot, _] = Spot.objects.get_or_create(**spot_data)
+        spot = upsert_spot(spot_data)
 
         create_document(document_list,
                         Document.DocumentType.Rapportage,

--- a/src/import_process/process_xls.py
+++ b/src/import_process/process_xls.py
@@ -179,6 +179,7 @@ def upsert_spot(spot_data: dict):
         for key, value in spot_data.items():
             if value is not None and hasattr(spot, key):
                 setattr(spot, key, value)
+        spot.save()
 
     except Spot.DoesNotExist as e:
         spot = Spot.objects.create(**spot_data)


### PR DESCRIPTION
Remove the get_or_create(**spot_data) because if even a little but of spot_data is different from an existing Spot it will create a new spot and causes a duplicate error because the spot.locatie_id is no longer unique then.

So update it to an upsert based on locatie_id.